### PR TITLE
Fix "Only owner can modify health" error

### DIFF
--- a/Assets/Scripts/Core/Entity/Unit/Controllers/Unit.AttributeController.cs
+++ b/Assets/Scripts/Core/Entity/Unit/Controllers/Unit.AttributeController.cs
@@ -586,7 +586,7 @@ namespace Core
 
             private void OnHealthStateChanged()
             {
-                SetHealth(unitState.Health);
+                Health.Set(unitState.Health);
             }
 
             private void OnComboPointsChanged()


### PR DESCRIPTION
The original code was calling the SetHealth() method, which is what the owner calls to update the health state property in Bolt. Then OnHealthStateChanged() is called through a property callback to update the clients, but it was attempting to set the same property again, rather than just updating the client about the updated health state, which was the intention here.

It was actually working correctly before since Bolt was just disregarding the client's attempt to set the health, and SetHealth() was also calling Health.Set(), but now it's still working correctly, without the "Only owner can modify health" error message in the log for clients.